### PR TITLE
It's GitHub and not Github. Just Fixed it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Keep-Github-Green :books:
+# Keep-GitHub-Green :books:
 
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/sagnik20/Keep-Github-Green/graphs/commit-activity) [![GitHub issues](https://img.shields.io/github/issues/sagnik20/Keep-Github-Green)](https://github.com/sagnik20/Keep-Github-Green/issues)
 [![GitHub forks](https://img.shields.io/github/forks/sagnik20/Keep-Github-Green?style=social)](https://github.com/sagnik20/Keep-Github-Green/network) [![GitHub stars](https://img.shields.io/github/stars/sagnik20/Keep-Github-Green?style=social)](https://github.com/sagnik20/Keep-Github-Green/stargazers) [![Open Source Love svg1](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
 
 
 A very warm welcome to all those who have landed here! :wave:
-This open source community is made to ease the work of all the CIEM students who are wiling to **Keep their Github Green throughout the month of June**
+This open source community is made to ease the work of all the CIEM students who are wiling to **Keep their GitHub Green throughout the month of June**
  
  
 ##### To contribute follow the guidelines in [Contributors.md](Contributors.md) 


### PR DESCRIPTION
While it's really great that GitHub is being 'kept' green. It becomes all the more important to write the name correctly for greater and greener impact. Cheers :-)
